### PR TITLE
Add support to register from nibs

### DIFF
--- a/Sources/ReusableKit.swift
+++ b/Sources/ReusableKit.swift
@@ -43,6 +43,15 @@ public struct ReusableCell<Cell: CellType> {
       .first ?? identifier ?? UUID().uuidString
     self.nib = nib
   }
+
+  /// A convenience initializer.
+  ///
+  /// - parameter identifier: A reuse identifier. Use random UUID string if identifier is not provided.
+  /// - parameter nibName: A name of nib.
+  public init(identifier: String? = nil, nibName: String) {
+    let nib = UINib(nibName: nibName, bundle: nil)
+    self.init(identifier: identifier, nib: nib)
+  }
 }
 
 public protocol ViewType: class {
@@ -62,5 +71,14 @@ public struct ReusableView<View: ViewType> {
   public init(identifier: String? = nil, nib: UINib? = nil) {
     self.identifier = identifier ?? UUID().uuidString
     self.nib = nib
+  }
+
+  /// A convenience initializer.
+  ///
+  /// - parameter identifier: A reuse identifier. Use random UUID string if identifier is not provided.
+  /// - parameter nibName: A name of nib.
+  public init(identifier: String? = nil, nibName: String) {
+    let nib = UINib(nibName: nibName, bundle: nil)
+    self.init(identifier: identifier, nib: nib)
   }
 }

--- a/Sources/ReusableKit.swift
+++ b/Sources/ReusableKit.swift
@@ -20,9 +20,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import Foundation
+import UIKit
 
 public protocol CellType: class {
+  var reuseIdentifier: String? { get }
 }
 
 /// A generic class that represents reusable cells.
@@ -30,12 +31,17 @@ public struct ReusableCell<Cell: CellType> {
   public typealias Class = Cell
 
   public let identifier: String
+  public let nib: UINib?
 
   /// Create and returns a new `ReusableCell` instance.
   ///
   /// - parameter identifier: A reuse identifier. Use random UUID string if identifier is not provided.
-  public init(identifier: String? = nil) {
-    self.identifier = identifier ?? UUID().uuidString
+  /// - parameter nib: A `UINib` instance. Use this when registering from xib.
+  public init(identifier: String? = nil, nib: UINib? = nil) {
+    self.identifier = nib?.instantiate(withOwner: nil, options: nil).lazy
+      .flatMap { ($0 as? CellType)?.reuseIdentifier }
+      .first ?? identifier ?? UUID().uuidString
+    self.nib = nib
   }
 }
 
@@ -47,11 +53,14 @@ public struct ReusableView<View: ViewType> {
   public typealias Class = View
 
   public let identifier: String
+  public let nib: UINib?
 
   /// Create and returns a new `ReusableView` instance.
   ///
   /// - parameter identifier: A reuse identifier. Use random UUID string if identifier is not provided.
-  public init(identifier: String? = nil) {
+  /// - parameter nib: A `UINib` instance. Use this when registering from xib.
+  public init(identifier: String? = nil, nib: UINib? = nil) {
     self.identifier = identifier ?? UUID().uuidString
+    self.nib = nib
   }
 }

--- a/Sources/UICollectionView+ReusableKit.swift
+++ b/Sources/UICollectionView+ReusableKit.swift
@@ -56,7 +56,11 @@ extension UICollectionView {
 
   /// Registers a generic cell for use in creating new collection view cells.
   public func register<Cell: CellType>(_ cell: ReusableCell<Cell>) {
-    self.register(Cell.self, forCellWithReuseIdentifier: cell.identifier)
+    if let nib = cell.nib {
+      self.register(nib, forCellWithReuseIdentifier: cell.identifier)
+    } else {
+      self.register(Cell.self, forCellWithReuseIdentifier: cell.identifier)
+    }
   }
 
   /// Returns a generic reusable cell located by its identifier.
@@ -73,7 +77,11 @@ extension UICollectionView {
 
   /// Registers a generic view for use in creating new supplementary views for the collection view.
   public func register<View: ViewType>(_ view: ReusableView<View>, kind: String) {
-    self.register(View.self, forSupplementaryViewOfKind: kind, withReuseIdentifier: view.identifier)
+    if let nib = view.nib {
+      self.register(nib, forSupplementaryViewOfKind: kind, withReuseIdentifier: view.identifier)
+    } else {
+      self.register(View.self, forSupplementaryViewOfKind: kind, withReuseIdentifier: view.identifier)
+    }
   }
 
   /// Returns a generic reusable supplementary view located by its identifier and kind.

--- a/Sources/UITableView+ReusableKit.swift
+++ b/Sources/UITableView+ReusableKit.swift
@@ -33,7 +33,11 @@ extension UITableView {
 
   /// Registers a generic cell for use in creating new table cells.
   public func register<Cell: CellType>(_ cell: ReusableCell<Cell>) {
-    self.register(Cell.self, forCellReuseIdentifier: cell.identifier)
+    if let nib = cell.nib {
+      self.register(nib, forCellReuseIdentifier: cell.identifier)
+    } else {
+      self.register(Cell.self, forCellReuseIdentifier: cell.identifier)
+    }
   }
 
   /// Returns a generic reusable cell located by its identifier.
@@ -50,7 +54,11 @@ extension UITableView {
 
   /// Registers a generic view for use in creating new table header or footer views.
   public func register<View: ViewType>(_ cell: ReusableView<View>) {
-    self.register(View.self, forHeaderFooterViewReuseIdentifier: cell.identifier)
+    if let nib = cell.nib {
+      self.register(nib, forHeaderFooterViewReuseIdentifier: cell.identifier)
+    } else {
+      self.register(View.self, forHeaderFooterViewReuseIdentifier: cell.identifier)
+    }
   }
 
   /// Returns a generic reusable header of footer view located by its identifier.


### PR DESCRIPTION
It resolves #3

``` swift
struct Reusable {
  static let myCell1 = ReusableCell<CollectionViewCell>(nib: UINib(nibName: "MyCell"))
  static let myCell2 = ReusableCell<CollectionViewCell>(nibName: "MyCell")
}
```

It will use the cell identifier from the nib if specified.
