### PR TITLE
Add a nib initializer to avoid hard coded nib name

### DIFF
--- a/Sources/ReusableKit/ReusableKit.swift
+++ b/Sources/ReusableKit/ReusableKit.swift
@@ -28,8 +28,14 @@ public struct ReusableCell<Cell: CellType> {
   ///
   /// - parameter identifier: A reuse identifier. Use random UUID string if identifier is not provided.
   /// - parameter nibName: A name of nib.
+  /// - parameter nibType: A type of nib.
   public init(identifier: String? = nil, nibName: String) {
     let nib = UINib(nibName: nibName, bundle: nil)
+    self.init(identifier: identifier, nib: nib)
+  }
+
+  public init<T>(identifier: String? = nil, nibType: T) {
+    let nib = UINib(nibName: String(describing: nibType.self), bundle: nil)
     self.init(identifier: identifier, nib: nib)
   }
 }
@@ -58,8 +64,14 @@ public struct ReusableView<View: ViewType> {
   ///
   /// - parameter identifier: A reuse identifier. Use random UUID string if identifier is not provided.
   /// - parameter nibName: A name of nib.
+  /// - parameter nibType: A type of nib.
   public init(identifier: String? = nil, nibName: String) {
     let nib = UINib(nibName: nibName, bundle: nil)
+    self.init(identifier: identifier, nib: nib)
+  }
+      
+  public init<T>(identifier: String? = nil, nibType: T) {
+    let nib = UINib(nibName: String(describing: nibType.self), bundle: nil)
     self.init(identifier: identifier, nib: nib)
   }
 }

--- a/Sources/ReusableKit/UITableView+ReusableKit.swift
+++ b/Sources/ReusableKit/UITableView+ReusableKit.swift
@@ -19,7 +19,7 @@ extension UITableView {
 
   /// Returns a generic reusable cell located by its identifier.
   public func dequeue<Cell>(_ cell: ReusableCell<Cell>) -> Cell? {
-    return self.dequeueReusableCell(withIdentifier: cell.identifier) as? Cell
+    return self.dequeueReusableCell(withIdentifier: cell.identifier) as! Cell
   }
 
   /// Returns a generic reusable cell located by its identifier.
@@ -40,7 +40,7 @@ extension UITableView {
 
   /// Returns a generic reusable header of footer view located by its identifier.
   public func dequeue<View>(_ view: ReusableView<View>) -> View? {
-    return self.dequeueReusableHeaderFooterView(withIdentifier: view.identifier) as? View
+    return self.dequeueReusableHeaderFooterView(withIdentifier: view.identifier) as! View
   }
 }
 #endif


### PR DESCRIPTION
This is one of inevitable hard coded string cases for nib.
-> ReusableCell<MyCell>(nibName: "MyCell")

In this pull request, we can init it without hard coded string anymore.
-> ReusableCell<MyCell>(nibType: MyCell.self)

That will be ok on condition of same string between nib and class name.